### PR TITLE
feat: add routing

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,6 +11,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@solidjs/router": "^0.8.2",
     "solid-js": "^1.6.10"
   },
   "devDependencies": {

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -1,9 +1,16 @@
 import type { Component } from 'solid-js';
+import { Routes, Route, Navigate } from '@solidjs/router';
+import { Home } from './pages/home';
+import { Onboarding } from './pages/onboarding';
 
 const App: Component = () => {
   return (
     <div class="w-[360px] h-[540px] bg-blue-200">
-      <h1>Home page</h1>
+      <Routes>
+        <Route path="/" element={<Navigate href="/index.html" />} />
+        <Route path="/index.html" component={Home} />
+        <Route path="/index.html/onboarding" component={Onboarding} />
+      </Routes>
     </div>
   );
 };

--- a/packages/app/src/components/link.tsx
+++ b/packages/app/src/components/link.tsx
@@ -1,0 +1,10 @@
+import type { ParentComponent } from 'solid-js';
+import { A } from '@solidjs/router';
+
+type LinkProps = {
+  path: `/${string}`;
+};
+
+export const Link: ParentComponent<LinkProps> = (props) => {
+  return <A href={`/index.html${props.path}`}>{props.children}</A>;
+};

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -9,6 +9,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  min-width: 360px;
+  min-height: 540px;
   width: 100vw;
   height: 100vh;
 

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,5 +1,6 @@
 /* @refresh reload */
 import { render } from 'solid-js/web';
+import { Router } from '@solidjs/router';
 import './index.css';
 import App from './app';
 
@@ -11,4 +12,11 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   );
 }
 
-render(() => <App />, root!);
+render(
+  () => (
+    <Router>
+      <App />
+    </Router>
+  ),
+  root!,
+);

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -1,0 +1,11 @@
+import type { Component } from 'solid-js';
+import { Link } from '../components/link';
+
+export const Home: Component = () => {
+  return (
+    <div>
+      <h1>Home page</h1>
+      <Link path="/onboarding">Go to onboarding</Link>
+    </div>
+  );
+};

--- a/packages/app/src/pages/onboarding.tsx
+++ b/packages/app/src/pages/onboarding.tsx
@@ -1,0 +1,11 @@
+import type { Component } from 'solid-js';
+import { Link } from '../components/link';
+
+export const Onboarding: Component = () => {
+  return (
+    <div>
+      <h1>Onboarding page</h1>
+      <Link path="/">Go to home page</Link>
+    </div>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
   packages/app:
     specifiers:
       '@crxjs/vite-plugin': 2.0.0-beta.15
+      '@solidjs/router': ^0.8.2
       autoprefixer: ^10.4.14
       postcss: ^8.4.21
       solid-js: ^1.6.10
@@ -43,6 +44,7 @@ importers:
       vite: ^4.1.1
       vite-plugin-solid: ^2.5.0
     dependencies:
+      '@solidjs/router': 0.8.2_solid-js@1.6.15
       solid-js: 1.6.15
     devDependencies:
       '@crxjs/vite-plugin': 2.0.0-beta.15
@@ -945,6 +947,14 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: true
+
+  /@solidjs/router/0.8.2_solid-js@1.6.15:
+    resolution: {integrity: sha512-gUKW+LZqxtX6y/Aw6JKyy4gQ9E7dLqp513oB9pSYJR1HM5c56Pf7eijzyXX+b3WuXig18Cxqah4tMtF0YGu80w==}
+    peerDependencies:
+      solid-js: ^1.5.3
+    dependencies:
+      solid-js: 1.6.15
+    dev: false
 
   /@types/babel__core/7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}


### PR DESCRIPTION
Closes #3 

Add routing

- Use official SolidJS [router](https://github.com/solidjs/solid-router)
- Add `Home` and `Onboarding` pages
- A `Link` component that always prefix urls with `/index.html`
- Redirect `/` to `/index.html`
- Fix forgotten `min-width` and `min-height`